### PR TITLE
Add Gemma orchestrator using lightweight ADK runtime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+.env
+.venv

--- a/README.md
+++ b/README.md
@@ -1,1 +1,51 @@
 # BOB14_ATG_MultiAgent
+
+This repository contains a lightweight reproduction of the Google Agent Development Kit (ADK) surface that is sufficient to build a Gemma3 orchestrator running against a local Ollama deployment. The orchestrator dynamically routes tasks to specialist agents (research, implementation, quality assurance, and generalist coordination) and exposes a command-line Development UI for manual experimentation.
+
+## Project layout
+
+- `google/adk/`: minimal ADK-compatible primitives (`Agent`, `Message`, `AgentRuntime`, tooling helpers, and an Ollama LLM client).
+- `orchestrator_app/`: orchestrator implementation, specialist agent definitions, configuration helpers, and a Development UI script.
+- `tests/`: unit tests that validate the orchestration logic using a deterministic fake LLM.
+
+## Requirements
+
+1. Python 3.11+
+2. [Ollama](https://ollama.ai) running locally with the `gemma3:12b` model pulled (`ollama pull gemma3:12b`).
+3. Install Python dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Running the Development UI
+
+Start your local Ollama runtime and then execute:
+
+```bash
+python -m orchestrator_app.dev_ui
+```
+
+Enter free-form tasks. The orchestrator will ask Gemma3 to choose the best specialist and then display both the routing decision and the delegated agent's response. Type `exit` to quit.
+
+## Programmatic usage
+
+```python
+from orchestrator_app import build_default_orchestrator
+from google.adk import AgentRuntime
+
+orchestrator = build_default_orchestrator()
+runtime = AgentRuntime(orchestrator)
+reply = runtime.send_user_message("Plan regression tests for the new parser")
+print(reply.content)
+```
+
+## Testing
+
+A deterministic fake LLM is provided to exercise the orchestration layer without requiring a running Ollama deployment:
+
+```bash
+pytest
+```
+
+The tests cover JSON-based routing, heuristic fallbacks, and ensure the orchestrator bundles delegated agent responses.

--- a/google/adk/__init__.py
+++ b/google/adk/__init__.py
@@ -1,0 +1,17 @@
+"""Minimal surface of the Google ADK package required by the orchestrator demo."""
+
+from .core import Agent, Message, Role
+from .llm import GemmaOllamaClient, OllamaError
+from .runtime import AgentRuntime
+from .tooling import Tool, ToolRegistry
+
+__all__ = [
+    "Agent",
+    "AgentRuntime",
+    "GemmaOllamaClient",
+    "Message",
+    "OllamaError",
+    "Role",
+    "Tool",
+    "ToolRegistry",
+]

--- a/google/adk/core.py
+++ b/google/adk/core.py
@@ -1,0 +1,52 @@
+"""Core abstractions for the minimal Google ADK runtime used in this project."""
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Dict, Iterable, Optional
+
+
+class Role(str, Enum):
+    """Conversation roles used in the orchestrator runtime."""
+
+    USER = "user"
+    ASSISTANT = "assistant"
+    SYSTEM = "system"
+    ORCHESTRATOR = "orchestrator"
+
+
+@dataclass
+class Message:
+    """Represents a single message exchanged between agents."""
+
+    role: Role
+    content: str
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def copy(self, **overrides: Any) -> "Message":
+        data = {"role": self.role, "content": self.content, "metadata": dict(self.metadata)}
+        data.update(overrides)
+        if "metadata" in data:
+            data["metadata"] = dict(data["metadata"])
+        return Message(**data)
+
+
+class Agent:
+    """Base class for any agent that participates in the runtime."""
+
+    def __init__(self, name: str, description: str, instructions: Optional[str] = None) -> None:
+        self.name = name
+        self.description = description
+        self.instructions = instructions or ""
+
+    def run(self, task: str, context: Iterable[Message]) -> Message:
+        """Execute the agent on the provided task."""
+
+        raise NotImplementedError("Agents must implement the run() method")
+
+    # Convenience API -----------------------------------------------------------------
+    def system_message(self) -> Message:
+        return Message(role=Role.SYSTEM, content=self.instructions, metadata={"agent": self.name})
+
+    def __repr__(self) -> str:  # pragma: no cover - debugging helper
+        return f"Agent(name={self.name!r})"

--- a/google/adk/llm.py
+++ b/google/adk/llm.py
@@ -1,0 +1,65 @@
+"""LLM client utilities tailored for the Ollama Gemma3 model."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Optional
+
+try:  # pragma: no cover - exercised indirectly in integration usage
+    import requests
+except ModuleNotFoundError:  # pragma: no cover - allows running without requests installed
+    requests = None  # type: ignore[assignment]
+
+
+class OllamaError(RuntimeError):
+    """Raised when the Ollama API returns an error."""
+
+
+@dataclass
+class GemmaOllamaClient:
+    """Thin HTTP client for talking to a local Ollama deployment."""
+
+    model: str = "gemma3:12b"
+    endpoint: str = "http://localhost:11434/api/generate"
+    timeout: int = 120
+
+    def complete(
+        self,
+        prompt: str,
+        *,
+        temperature: float = 0.2,
+        max_tokens: Optional[int] = None,
+        json_mode: bool = False,
+    ) -> str:
+        payload: Dict[str, Any] = {
+            "model": self.model,
+            "prompt": prompt,
+            "stream": False,
+            "options": {"temperature": temperature},
+        }
+        if max_tokens is not None:
+            payload["options"]["num_predict"] = max_tokens
+        if json_mode:
+            payload["format"] = "json"
+        if requests is None:  # pragma: no cover - triggered only when dependency missing
+            raise OllamaError(
+                "The 'requests' package is required to call the Ollama HTTP API. "
+                "Install dependencies with `pip install -r requirements.txt`."
+            )
+        try:
+            response = requests.post(self.endpoint, json=payload, timeout=self.timeout)
+            response.raise_for_status()
+        except requests.RequestException as exc:  # pragma: no cover - network failure path
+            raise OllamaError("Failed to reach the Ollama runtime") from exc
+        data = response.json()
+        text = data.get("response")
+        if text is None:
+            raise OllamaError(f"Unexpected Ollama response: {json.dumps(data)[:200]}")
+        return text
+
+    def complete_json(self, prompt: str, *, temperature: float = 0.0) -> Dict[str, Any]:
+        text = self.complete(prompt, temperature=temperature, json_mode=True)
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError as exc:
+            raise OllamaError("Gemma did not return valid JSON") from exc

--- a/google/adk/runtime.py
+++ b/google/adk/runtime.py
@@ -1,0 +1,24 @@
+"""Simplified runtime loop for orchestrating agents."""
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from .core import Agent, Message, Role
+
+
+class AgentRuntime:
+    """Maintains conversation state and delegates work to the orchestrator agent."""
+
+    def __init__(self, orchestrator: Agent) -> None:
+        self.orchestrator = orchestrator
+        self.history: List[Message] = []
+
+    def send_user_message(self, content: str) -> Message:
+        message = Message(role=Role.USER, content=content)
+        self.history.append(message)
+        response = self.orchestrator.run(content, list(self.history))
+        self.history.append(response)
+        return response
+
+    def replay(self) -> Iterable[Message]:
+        return list(self.history)

--- a/google/adk/tooling.py
+++ b/google/adk/tooling.py
@@ -1,0 +1,44 @@
+"""Tooling primitives inspired by the Google ADK interfaces."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable, Dict, Iterable
+
+
+@dataclass
+class Tool:
+    """Represents an executable function exposed to an agent."""
+
+    name: str
+    description: str
+    handler: Callable[[str], str]
+
+    def __call__(self, input_text: str) -> str:
+        return self.handler(input_text)
+
+
+class ToolRegistry:
+    """Simple registry that mimics the ADK tool management utilities."""
+
+    def __init__(self) -> None:
+        self._tools: Dict[str, Tool] = {}
+
+    def add(self, tool: Tool) -> None:
+        if tool.name in self._tools:
+            raise ValueError(f"Tool {tool.name!r} is already registered")
+        self._tools[tool.name] = tool
+
+    def get(self, name: str) -> Tool:
+        try:
+            return self._tools[name]
+        except KeyError as exc:  # pragma: no cover - defensive branch
+            raise KeyError(f"Unknown tool: {name}") from exc
+
+    def list(self) -> Iterable[Tool]:
+        return self._tools.values()
+
+    def describe(self) -> str:
+        descriptions = []
+        for tool in self._tools.values():
+            descriptions.append(f"- {tool.name}: {tool.description}")
+        return "\n".join(descriptions)

--- a/orchestrator_app/__init__.py
+++ b/orchestrator_app/__init__.py
@@ -1,0 +1,26 @@
+"""Utilities for building and running the Gemma orchestrator demo."""
+
+from .agents import (
+    CodingAgent,
+    GeneralistAgent,
+    LLMAgent,
+    ResearchAgent,
+    TestingAgent,
+    build_specialist_agents,
+)
+from .config import OllamaSettings, load_ollama_settings
+from .orchestrator import GemmaTaskOrchestrator, SelectionResult, build_default_orchestrator
+
+__all__ = [
+    "CodingAgent",
+    "GeneralistAgent",
+    "GemmaTaskOrchestrator",
+    "LLMAgent",
+    "OllamaSettings",
+    "ResearchAgent",
+    "SelectionResult",
+    "TestingAgent",
+    "build_default_orchestrator",
+    "build_specialist_agents",
+    "load_ollama_settings",
+]

--- a/orchestrator_app/agents.py
+++ b/orchestrator_app/agents.py
@@ -1,0 +1,109 @@
+"""Specialist agents that the orchestrator can route work to."""
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from google.adk import Agent, GemmaOllamaClient, Message, Role
+
+
+class LLMAgent(Agent):
+    """Base class for simple LLM powered agents."""
+
+    def __init__(
+        self,
+        name: str,
+        description: str,
+        instructions: str,
+        llm: GemmaOllamaClient,
+        *,
+        temperature: float = 0.2,
+    ) -> None:
+        super().__init__(name=name, description=description, instructions=instructions)
+        self.llm = llm
+        self.temperature = temperature
+
+    def build_prompt(self, task: str, context: Iterable[Message]) -> str:
+        transcript: List[str] = []
+        for message in context:
+            speaker = message.metadata.get("agent", message.role.value)
+            transcript.append(f"[{speaker}] {message.content}")
+        history_block = "\n".join(transcript) if transcript else "(no previous conversation)"
+        prompt = (
+            f"You are {self.name}.\n"
+            f"Role description: {self.description}.\n"
+            f"Operating instructions: {self.instructions}.\n"
+            f"Conversation so far:\n{history_block}\n"
+            f"Task: {task}\n"
+            "Provide a concise, actionable response."
+        )
+        return prompt
+
+    def run(self, task: str, context: Iterable[Message]) -> Message:
+        prompt = self.build_prompt(task, context)
+        content = self.llm.complete(prompt, temperature=self.temperature)
+        return Message(role=Role.ASSISTANT, content=content, metadata={"agent": self.name})
+
+
+class ResearchAgent(LLMAgent):
+    def __init__(self, llm: GemmaOllamaClient) -> None:
+        super().__init__(
+            name="Research Analyst",
+            description="Collects background knowledge and synthesises findings",
+            instructions=(
+                "Focus on decomposing the problem, highlight relevant background "
+                "information, and cite potential research directions."
+            ),
+            llm=llm,
+            temperature=0.1,
+        )
+
+
+class CodingAgent(LLMAgent):
+    def __init__(self, llm: GemmaOllamaClient) -> None:
+        super().__init__(
+            name="Implementation Engineer",
+            description="Designs and implements code changes",
+            instructions=(
+                "Translate requirements into code sketches, include architecture "
+                "decisions, and flag dependencies or risks."
+            ),
+            llm=llm,
+            temperature=0.15,
+        )
+
+
+class TestingAgent(LLMAgent):
+    def __init__(self, llm: GemmaOllamaClient) -> None:
+        super().__init__(
+            name="Quality Strategist",
+            description="Plans validation strategies and edge case coverage",
+            instructions=(
+                "Propose automated and manual validation steps, prioritise reliability, "
+                "and enumerate measurable success criteria."
+            ),
+            llm=llm,
+            temperature=0.15,
+        )
+
+
+class GeneralistAgent(LLMAgent):
+    def __init__(self, llm: GemmaOllamaClient) -> None:
+        super().__init__(
+            name="Generalist Collaborator",
+            description="Handles broad coordination or ambiguous tasks",
+            instructions=(
+                "Provide balanced reasoning, combine insights from research, coding, "
+                "and testing perspectives, and maintain clarity."
+            ),
+            llm=llm,
+            temperature=0.2,
+        )
+
+
+def build_specialist_agents(llm: GemmaOllamaClient) -> List[LLMAgent]:
+    return [
+        ResearchAgent(llm),
+        CodingAgent(llm),
+        TestingAgent(llm),
+        GeneralistAgent(llm),
+    ]

--- a/orchestrator_app/config.py
+++ b/orchestrator_app/config.py
@@ -1,0 +1,20 @@
+"""Configuration helpers for the orchestrator demo."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+def _env(key: str, default: str) -> str:
+    return os.environ.get(key, default)
+
+
+@dataclass
+class OllamaSettings:
+    model: str = _env("OLLAMA_MODEL", "gemma3:12b")
+    endpoint: str = _env("OLLAMA_ENDPOINT", "http://localhost:11434/api/generate")
+    temperature: float = float(_env("OLLAMA_TEMPERATURE", "0.2"))
+
+
+def load_ollama_settings() -> OllamaSettings:
+    return OllamaSettings()

--- a/orchestrator_app/dev_ui.py
+++ b/orchestrator_app/dev_ui.py
@@ -1,0 +1,50 @@
+"""Command line Development UI for exercising the orchestrator."""
+from __future__ import annotations
+
+from rich.console import Console
+from rich.panel import Panel
+from rich.prompt import Prompt
+
+from google.adk import AgentRuntime, GemmaOllamaClient
+
+from .config import load_ollama_settings
+from .orchestrator import build_default_orchestrator
+
+console = Console()
+
+
+def launch_chat() -> None:
+    settings = load_ollama_settings()
+    llm = GemmaOllamaClient(
+        model=settings.model,
+        endpoint=settings.endpoint,
+        timeout=120,
+    )
+    orchestrator = build_default_orchestrator(
+        llm=llm,
+        classification_temperature=settings.temperature,
+    )
+    runtime = AgentRuntime(orchestrator)
+    console.print(
+        Panel(
+            "Enter your task to see how the orchestrator delegates work. "
+            "Type 'exit' to quit.",
+            title="Gemma Orchestrator Development UI",
+        )
+    )
+    while True:
+        user_input = Prompt.ask("[bold cyan]You[/]")
+        if user_input.strip().lower() in {"exit", "quit"}:
+            console.print("Exiting Development UI.")
+            break
+        try:
+            response = runtime.send_user_message(user_input)
+        except Exception as exc:  # pragma: no cover - runtime guard
+            console.print(f"[bold red]Error:[/] {exc}")
+            continue
+        title = f"Delegated to: {response.metadata.get('delegated_to', 'unknown')}"
+        console.print(Panel(response.content, title=title))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual entry point
+    launch_chat()

--- a/orchestrator_app/orchestrator.py
+++ b/orchestrator_app/orchestrator.py
@@ -1,0 +1,131 @@
+"""Gemma-powered orchestrator built on top of the lightweight ADK primitives."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Dict, Iterable, List, Sequence
+
+from google.adk import Agent, GemmaOllamaClient, Message, Role
+
+from .agents import LLMAgent, build_specialist_agents
+
+
+@dataclass
+class SelectionResult:
+    agent: str
+    confidence: float
+    reasoning: str
+
+
+class GemmaTaskOrchestrator(Agent):
+    """Routes tasks to specialist agents using a Gemma3 reasoning call."""
+
+    def __init__(
+        self,
+        llm: GemmaOllamaClient,
+        agents: Sequence[LLMAgent],
+        *,
+        classification_temperature: float = 0.0,
+    ) -> None:
+        super().__init__(
+            name="Gemma Orchestrator",
+            description="Delegates work to the most suitable specialist agent",
+            instructions=(
+                "Select the best agent for the task, explain the routing decision, "
+                "and ensure the final response aggregates the agent output."
+            ),
+        )
+        self.llm = llm
+        self.agents: Dict[str, LLMAgent] = {agent.name: agent for agent in agents}
+        self.classification_temperature = classification_temperature
+
+    def _agent_directory(self) -> str:
+        rows = []
+        for agent in self.agents.values():
+            rows.append(f"{agent.name}: {agent.description}\nInstructions: {agent.instructions}")
+        return "\n\n".join(rows)
+
+    def _build_selection_prompt(self, task: str, context: Iterable[Message]) -> str:
+        transcript: List[str] = []
+        for message in context:
+            speaker = message.metadata.get("agent", message.role.value)
+            transcript.append(f"[{speaker}] {message.content}")
+        history_block = "\n".join(transcript) if transcript else "(no previous conversation)"
+        prompt = (
+            "You are the orchestrator deciding which specialist agent should handle a task.\n"
+            "Consider the capabilities listed below and choose the best fit.\n"
+            f"Available agents:\n{self._agent_directory()}\n\n"
+            f"Conversation so far:\n{history_block}\n\n"
+            f"Incoming task: {task}\n\n"
+            "Respond with a JSON object with keys 'agent', 'confidence', and 'reasoning'.\n"
+            "The confidence should be a value between 0 and 1."
+        )
+        return prompt
+
+    def _parse_selection(self, response: str, task: str) -> SelectionResult:
+        try:
+            data = json.loads(response)
+            agent_name = data.get("agent")
+            if agent_name not in self.agents:
+                raise KeyError
+            confidence = float(data.get("confidence", 0.0))
+            reasoning = str(data.get("reasoning", ""))
+            return SelectionResult(agent=agent_name, confidence=confidence, reasoning=reasoning)
+        except Exception:
+            # Fallback heuristic based on keyword matching
+            lower = task.lower()
+            if any(keyword in lower for keyword in ["test", "qa", "validate", "quality"]):
+                agent_name = "Quality Strategist"
+            elif any(keyword in lower for keyword in ["implement", "code", "refactor", "bug"]):
+                agent_name = "Implementation Engineer"
+            elif any(keyword in lower for keyword in ["research", "investigate", "analyz", "plan"]):
+                agent_name = "Research Analyst"
+            else:
+                agent_name = "Generalist Collaborator"
+            return SelectionResult(agent=agent_name, confidence=0.1, reasoning="Fallback heuristic")
+
+    def select_agent(self, task: str, context: Iterable[Message]) -> SelectionResult:
+        prompt = self._build_selection_prompt(task, context)
+        try:
+            selection_json = self.llm.complete(
+                prompt,
+                temperature=self.classification_temperature,
+                json_mode=True,
+            )
+        except Exception:
+            # When the Gemma client cannot be reached, fall back to heuristics.
+            selection_json = ""
+        return self._parse_selection(selection_json, task)
+
+    def run(self, task: str, context: Iterable[Message]) -> Message:
+        selection = self.select_agent(task, context)
+        agent = self.agents[selection.agent]
+        agent_response = agent.run(task, context)
+        combined_content = (
+            f"Routing decision: {selection.agent} (confidence {selection.confidence:.2f}).\n"
+            f"Reasoning: {selection.reasoning or 'N/A'}.\n\n"
+            f"{selection.agent}'s response:\n{agent_response.content}"
+        )
+        return Message(
+            role=Role.ORCHESTRATOR,
+            content=combined_content,
+            metadata={
+                "agent": self.name,
+                "delegated_to": selection.agent,
+                "confidence": selection.confidence,
+            },
+        )
+
+
+def build_default_orchestrator(
+    *,
+    llm: GemmaOllamaClient | None = None,
+    classification_temperature: float = 0.0,
+) -> GemmaTaskOrchestrator:
+    llm = llm or GemmaOllamaClient()
+    agents = build_specialist_agents(llm)
+    return GemmaTaskOrchestrator(
+        llm=llm,
+        agents=agents,
+        classification_temperature=classification_temperature,
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+requests>=2.32.0
+rich>=13.7.0
+pytest>=8.2.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import json
+
+from orchestrator_app.orchestrator import build_default_orchestrator
+
+
+class FakeLLM:
+    def __init__(self) -> None:
+        self.classification_responses: dict[str, dict[str, object]] = {}
+
+    def register_classification(self, needle: str, agent: str, confidence: float, reasoning: str) -> None:
+        self.classification_responses[needle] = {
+            "agent": agent,
+            "confidence": confidence,
+            "reasoning": reasoning,
+        }
+
+    def complete(self, prompt: str, *, temperature: float = 0.2, max_tokens=None, json_mode: bool = False):
+        if json_mode:
+            for needle, payload in self.classification_responses.items():
+                if needle in prompt:
+                    return json.dumps(payload)
+            return "{}"
+        if "You are Implementation Engineer" in prompt:
+            return "Implementation details"
+        if "You are Quality Strategist" in prompt:
+            return "Test plan"
+        if "You are Research Analyst" in prompt:
+            return "Research summary"
+        return "General response"
+
+
+def test_orchestrator_routes_using_llm_json():
+    llm = FakeLLM()
+    llm.register_classification(
+        needle="Implement a parser",
+        agent="Implementation Engineer",
+        confidence=0.82,
+        reasoning="Coding focused",
+    )
+    orchestrator = build_default_orchestrator(llm=llm)
+    response = orchestrator.run("Implement a parser", [])
+    assert response.metadata["delegated_to"] == "Implementation Engineer"
+    assert "confidence 0.82" in response.content
+    assert "Implementation details" in response.content
+
+
+def test_orchestrator_falls_back_to_keyword_matching():
+    llm = FakeLLM()
+    orchestrator = build_default_orchestrator(llm=llm)
+    response = orchestrator.run("Design regression tests", [])
+    assert response.metadata["delegated_to"] == "Quality Strategist"
+    assert "Test plan" in response.content


### PR DESCRIPTION
## Summary
- implement a lightweight subset of the Google ADK primitives together with an Ollama Gemma client
- add specialist LLM agents, a Gemma-driven orchestrator, and a command-line Development UI
- document setup instructions and cover orchestration flows with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9331e01588320ab89505feec808f7